### PR TITLE
Feature/font deduplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "genpdfi"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "derive_more",
  "float-cmp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genpdfi"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Robin Krahl <robin.krahl@ireas.org>", "Ismael Sh <me@theiskaa.com>"]
 edition = "2018"
 description = "User-friendly PDF generator written in pure Rust"


### PR DESCRIPTION
The genpdfi library was duplicating font data when multiple FontData instances were created from the same underlying font file. When a FontFamily was created with 4 variants (regular, bold, italic, bold-italic), each variant stored its own complete copy of the font data, leading to 4x memory usage and 4x PDF file size bloat. A simple 3-line document was generating 736KB PDFs because it embedded ~168KB font data 4 times.

**Solution:**
Modified the font storage system to use Arc<Vec<u8>> for shared font data ownership. Added a new FontData::new_shared() method that allows multiple FontData instances to reference the same underlying font data without duplication. Implemented a font deduplication cache in FontCache::load_pdf_fonts() that prevents embedding identical font data multiple times in the PDF output. The cache uses Arc pointer comparison to identify when the same font data is being embedded and reuses the existing PDF font reference.

**Technical Changes:**
- Changed RawFontData::Embedded from Vec<u8> to Arc<Vec<u8>>
- Added FontData::new_shared() method for creating FontData instances that share underlying data
- Added embedded_font_cache HashMap to FontCache struct for deduplication
- Modified FontCache::load_pdf_fonts() to check cache before embedding fonts
- Updated font embedding logic to handle Arc dereferencing properly

as a result PDF file sizes reduced from 736KB to 186KB (75% reduction) for documents that reuse the same font data across multiple variants.


For more information you can check out https://github.com/theiskaa/markdown2pdf/issues/32